### PR TITLE
Set XDG_SESSION_TYPE to x11

### DIFF
--- a/wayback.c
+++ b/wayback.c
@@ -923,6 +923,7 @@ int main(int argc, char *argv[]) {
 		usleep(500000);
 
 		setenv("WAYLAND_DISPLAY", "", true);
+                setenv("XDG_SESSION_TYPE", "x11", true);
 		setenv("DISPLAY", x_display, true);
 		execvp(startup_cmd[0], startup_cmd);
 	}


### PR DESCRIPTION
XDG_SESSION_TYPE is automatically set to wayland, it should be `x11`