### PR TITLE
wayback-session: Dont set WAYLAND_DISPLAY

### DIFF
--- a/wayback-session/wayback-session.c
+++ b/wayback-session/wayback-session.c
@@ -91,7 +91,6 @@ int main(int argc, char* argv[]) {
 	session_pid = fork();
 	if (session_pid == 0) {
 		setenv("XDG_SESSION_TYPE", "x11", true);
-		setenv("WAYLAND_DISPLAY", "", true);
 		setenv("DISPLAY", x_display, true);
 		if (xinitrc_path != NULL) {
 			execlp("sh", "sh", xinitrc_path, (void*)NULL);


### PR DESCRIPTION
wayback-session still sets `WAYLAND_DISPLAY` to an empty string, this isn't needed anymore since we don't use 'traditional' wayland sockets anymore, which means that `wayback-compositor` doesn't set `WAYLAND_DISPLAY` in the first place

closes #24 