### PR TITLE
Ctrl alt keybind

### DIFF
--- a/wayback-compositor/wayback-compositor.c
+++ b/wayback-compositor/wayback-compositor.c
@@ -179,7 +179,7 @@ static void keyboard_handle_key(
 
 	bool handled = false;
 	uint32_t modifiers = wlr_keyboard_get_modifiers(keyboard->wlr_keyboard);
-	if ((modifiers & (WLR_MODIFIER_ALT|WLR_MODIFIER_CTRL)) &&
+	if ((modifiers & WLR_MODIFIER_ALT && modifiers & WLR_MODIFIER_CTRL) &&
 			event->state == WL_KEYBOARD_KEY_STATE_PRESSED) {
 		/* If alt is held down and this button was _pressed_, we attempt to
 		 * process it as a compositor keybinding. */


### PR DESCRIPTION
The added keybind in https://github.com/kaniini/wayback/commit/b73331578451f3a65b305f1d2adb7d7785260ec3 triggers on either ctrl+backspace or alt+backspace, mainly ctrl+backspace can cause issues as its a traditional bind in text editors, instead wayback-compositor should only register ctrl+alt+backspace