### PR TITLE
meson, xwayback: Detect and use the Xwayland binary found at build time

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -34,6 +34,7 @@ jobs:
             wayland-dev \
             wayland-protocols \
             wlroots-dev \
+            xwayland-dev \
             scdoc
       - name: Install dependencies
         if: matrix.distro == 'arch'
@@ -44,6 +45,7 @@ jobs:
             wayland \
             wayland-protocols \
             wlroots0.19 \
+            xorg-xwayland \
             scdoc
       - name: Install dependencies
         if: matrix.distro == 'fedora'
@@ -58,7 +60,8 @@ jobs:
             'pkgconfig(wayland-protocols)' \
             'pkgconfig(wayland-server)' \
             'pkgconfig(wlroots-0.19)' \
-            'pkgconfig(xkbcommon)'
+            'pkgconfig(xkbcommon)' \
+            'pkgconfig(xwayland)'
       - name: Set up problem matcher
         uses: misyltoad/gcc-problem-matcher@master
       - name: Configure project

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Dependencies:
 - wayland-protocol >=1.14
 - xkbcommon
 - wlroots-0.19
+- xwayland >= 24.1
 
 Building:
 ```

--- a/meson.build
+++ b/meson.build
@@ -11,7 +11,11 @@ wayland_cursor = dependency('wayland-cursor')
 wayland_egl    = dependency('wayland-egl')
 wayland_protos = dependency('wayland-protocols', version: '>=1.14')
 xkbcommon      = dependency('xkbcommon')
+xwayland       = dependency('xwayland', version: '>=24.1')
 wlroots        = dependency('wlroots-0.19')
+
+xwayland_executable_path = xwayland.get_variable(pkgconfig: 'xwayland')
+add_global_arguments('-DXWAYLAND_EXEC_PATH="@0@"'.format(xwayland_executable_path), language : 'c')
 
 subdir('protocol')
 subdir('wayback-compositor')

--- a/xwayback/xwayback.c
+++ b/xwayback/xwayback.c
@@ -187,6 +187,12 @@ void handle_exit(int sig) {
 	}
 }
 
+static const char *basename_c(const char *path)
+{
+	const char *slash = strrchr(path, '/');
+	return slash ? ++slash : path;
+}
+
 __attribute__((noreturn)) static void usage(char *binname) {
 	fprintf(stderr, "usage: %s [-d :display]\n", binname);
 	exit(EXIT_SUCCESS);
@@ -290,9 +296,9 @@ int main(int argc, char* argv[]) {
 		snprintf(geometry, sizeof(geometry), "%dx%d", xwayback->first_output->width, xwayback->first_output->height);
 
 		if (x_display)
-			execlp("Xwayland", "Xwayland", x_display, "-fullscreen", "-retro", "-geometry", geometry, (void*)NULL);
+			execl(XWAYLAND_EXEC_PATH, basename_c(XWAYLAND_EXEC_PATH), x_display, "-fullscreen", "-retro", "-geometry", geometry, (void*)NULL);
 		else {
-			execlp("Xwayland", "Xwayland", "-displayfd", displayfd, "-fullscreen", "-retro", "-geometry", geometry, (void*)NULL);
+			execl(XWAYLAND_EXEC_PATH, basename_c(XWAYLAND_EXEC_PATH), "-displayfd", displayfd, "-fullscreen", "-retro", "-geometry", geometry, (void*)NULL);
 		}
 		fprintf(stderr, "ERROR: failed to launch Xwayland\n");
 		exit(EXIT_FAILURE);


### PR DESCRIPTION
This ensures that we use the expected Xwayland binary for Xwayback.